### PR TITLE
Fix to return only True conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ nosetests.xml
 .idea/
 tests/__pycache__/
 .cache/
+business-rules.iml

--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -56,18 +56,16 @@ def check_conditions_recursively(conditions, defined_variables, rule):
             check_condition_result, matches_results = check_conditions_recursively(condition, defined_variables, rule)
             matches.extend(matches_results)
             if not check_condition_result:
-                return False, matches
+                return False, []
         return True, matches
 
     elif keys == ['any']:
         assert len(conditions['any']) >= 1
-        matches = []
         for condition in conditions['any']:
             check_condition_result, matches_results = check_conditions_recursively(condition, defined_variables, rule)
-            matches.extend(matches_results)
             if check_condition_result:
-                return True, matches
-        return False, matches
+                return True, matches_results
+        return False, []
 
     else:
         # help prevent errors - any and all can only be in the condition dict

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -539,17 +539,17 @@ class EngineCheckConditionsTests(TestCase):
 
     def test_case13(self):
         """
-        (cond2: true and cond3: false) or cond1: true => [cond2, cond3]
+        (cond1: true and cond2: false) or cond3: true => [cond3]
         """
         conditions = {
             'any': [
                 {
                     'all': [
-                        {'name': 'true_variable', 'operator': 'is_true', 'value': '2'},
-                        {'name': 'true_variable', 'operator': 'is_false', 'value': '3'},
+                        {'name': 'true_variable', 'operator': 'is_true', 'value': '1'},
+                        {'name': 'true_variable', 'operator': 'is_false', 'value': '2'},
                     ]
                 },
-                {'name': 'true_variable', 'operator': 'is_true', 'value': '1'},
+                {'name': 'true_variable', 'operator': 'is_true', 'value': '3'},
             ]
         }
         variables = TrueVariables()
@@ -557,7 +557,7 @@ class EngineCheckConditionsTests(TestCase):
 
         result = engine.check_conditions_recursively(conditions, variables, rule)
         self.assertEqual(result, (True, [
-            ConditionResult(result=True, name='true_variable', operator='is_true', value='1', parameters={}),
+            ConditionResult(result=True, name='true_variable', operator='is_true', value='3', parameters={}),
         ]))
 
 

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -537,6 +537,29 @@ class EngineCheckConditionsTests(TestCase):
             ConditionResult(result=True, name='true_variable', operator='is_true', value='1', parameters={}),
         ]))
 
+    def test_case13(self):
+        """
+        (cond2: true and cond3: false) or cond1: true => [cond2, cond3]
+        """
+        conditions = {
+            'any': [
+                {
+                    'all': [
+                        {'name': 'true_variable', 'operator': 'is_true', 'value': '2'},
+                        {'name': 'true_variable', 'operator': 'is_false', 'value': '3'},
+                    ]
+                },
+                {'name': 'true_variable', 'operator': 'is_true', 'value': '1'},
+            ]
+        }
+        variables = TrueVariables()
+        rule = {'conditions': conditions, 'actions': []}
+
+        result = engine.check_conditions_recursively(conditions, variables, rule)
+        self.assertEqual(result, (True, [
+            ConditionResult(result=True, name='true_variable', operator='is_true', value='1', parameters={}),
+        ]))
+
 
 class TrueVariables(BaseVariables):
     from business_rules.variables import boolean_rule_variable

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -109,7 +109,7 @@ class EngineTests(TestCase):
         rule = {"conditions": conditions, "actions": []}
 
         result = engine.check_conditions_recursively(conditions, variables, rule)
-        self.assertEqual(result, (False, [(False,)]))
+        self.assertEqual(result, (False, []))
         engine.check_condition.assert_called_once_with({'thing1': ''}, variables, rule)
 
     def test_check_all_condition_with_no_items_fails(self):
@@ -136,7 +136,7 @@ class EngineTests(TestCase):
         rule = {'conditions': conditions, 'actions': []}
 
         result = engine.check_conditions_recursively(conditions, variables, rule)
-        self.assertEqual(result, (False, [(False,), (False,)]))
+        self.assertEqual(result, (False, []))
         # assert call count and most recent call are as expected
         self.assertEqual(engine.check_condition.call_count, 2)
         engine.check_condition.assert_called_with(conditions['any'][1], variables, rule)


### PR DESCRIPTION
Fix to change business rules engine to return ALL conditions that were `true` in order to trigger the rule.
Examples:
```
cond1: true and cond2: false => []
cond1: false and cond2: true => []
cond1: true and cond2: true => [cond1, cond2]
```
```
cond1: true or cond2: false => [cond1]
cond1: false or cond2: true => [cond2]
cond1: true or cond2: true => [cond1]
```
```
cond1: true and (cond2: false or cond3: true) => [cond1, cond3]
cond1: false and (cond2: false or cond3: true) => []
cond1: true and (cond2: true or cond3: true) => [cond1, cond2]
```
```
cond1: true or (cond2: false or cond3: true) => [cond1]
cond1: false or (cond2: false or cond3: true) => [cond3]
cond1: false or (cond2: true or cond3: false) => [cond2]
cond1: false or (cond2: true or cond3: true) => [cond2]
```
```
cond1: true or (cond2: false and cond3: true) => [cond1]
cond1: false or (cond2: false and cond3: true) => []
cond1: false or (cond2: true and cond3: false) => []
cond1: false or (cond2: true and cond3: true) => [cond2, cond3]
```